### PR TITLE
Charset při spojení

### DIFF
--- a/www/app/db_connect.php
+++ b/www/app/db_connect.php
@@ -3,8 +3,7 @@
 function db_connect($host,$user,$pass){
   if(!class_exists("NotORM")) require APP_DIR."/lib/notorm/NotORM.php";
   
-  $driver_config = array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8"); 
-  $pdo = new PDO("mysql:dbname=".PROFILE_DB.";host=$host",$user,$pass,$driver_config);
+  $pdo = new PDO("mysql:dbname=".PROFILE_DB.";host=$host;charset=utf8",$user,$pass); 
   $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     
   $cache = null;
@@ -14,8 +13,6 @@ function db_connect($host,$user,$pass){
   
   function db_debug($query){global $queries;$queries[] = $query;}
   $db->debug = "db_debug";
-  
-  unset($driver_config);
   
   $GLOBALS["pdo"] = $pdo;
   


### PR DESCRIPTION
Charset by měl být určen v DSN, aby o znakové sadě věděl i klient, jinak použije default pro escapování a v některých znakových sadách (GBK) může za některých podmínek dojít k SQL Injection i přes použití `quote()`
